### PR TITLE
Fixes for building under gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # libocto is developed with clang:
 CC=clang
-CFLAGS= -Wall -Wextra -Werror -pedantic -O2 -pipe -march=native
+CFLAGS= -Wall -Wextra -Werror -pedantic -O2 -pipe -march=native -std=gnu11
 DEBUG_CFLAGS= -Wall -Wextra -Werror -pedantic -O0 -g -ggdb -pipe -DDEBUG_MSG_ENABLE
 INCLUDE= -I./include
 

--- a/src/octo/keygen.c
+++ b/src/octo/keygen.c
@@ -1,5 +1,9 @@
 // libocto Copyright (C) Travis Whitaker 2013-2014
 
+#ifdef __GNUC__
+#define _GNU_SOURCE
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@
 
 # libocto is developed with clang:
 CC=clang
-CFLAGS= -Wall -Wextra -Werror -pedantic -O2 -pipe -march=native
+CFLAGS= -Wall -Wextra -Werror -pedantic -O2 -pipe -march=native -std=gnu11
 DEBUG_CFLAGS= -Wall -Wextra -Werror -pedantic -O0 -g -pipe -DDEBUG_MSG_ENABLE
 INCLUDE= -I../include
 LFLAGS = -L../ -locto


### PR DESCRIPTION
- If CC is set to gcc, the standard must be explicitly set to gnu11
- If building under gcc without a gnu standard, _GNU_SOURCE must be defined
